### PR TITLE
Fix Monaco CSP for CDN assets

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -396,6 +396,27 @@ phone and city. **Replace them before the site goes anywhere public.** They
 are grouped in one named constant rather than scattered through the markup
 precisely so they are hard to miss.
 
+**The CSP has to allow the CDN for scripts, styles *and* fonts.** Monaco is
+fetched by `@monaco-editor/react` rather than bundled, and Pyodide is fetched
+by `public/python-worker.js`; both come from `cdn.jsdelivr.net`.
+
+`script-src` allowed it and `style-src` did not, so Monaco's JavaScript loaded
+while `editor.main.css` was refused. Monaco then rendered without the rules
+that position its hidden `<textarea>` and map clicks onto text: the textarea
+showed up as a plain resizable form field floating over the code, complete with
+the browser's own resize grip, and the caret stopped following the mouse. It
+was reported as "the cursor is stuck and there are boxes", which is exactly
+what it looked like — nothing in it pointed at a blocked stylesheet.
+
+Two things about that failure are worth remembering. It appears **only in a
+browser**, so `tsc`, `eslint`, `next build` and CI were all green throughout.
+And Monaco ships its icons as `codicon.ttf` from the same path, so `font-src`
+needs the CDN too or the editor silently loses its icons.
+
+The policy in `web/next.config.ts` is now a list of directives with the reason
+written next to it, rather than one long string in which a missing entry is
+invisible.
+
 **Monaco needs `automaticLayout: true`, and it is not optional here.** It
 caches its container's size and maps mouse coordinates against that cache, so
 once the container has resized without it being told, clicks put the caret

--- a/web/next.config.ts
+++ b/web/next.config.ts
@@ -1,18 +1,66 @@
 import type { NextConfig } from "next";
 
+/**
+ * Where third-party code is loaded from at runtime.
+ *
+ * Two things come from here and neither is optional: Monaco, which
+ * @monaco-editor/react fetches rather than bundling, and Pyodide, which
+ * public/python-worker.js pulls in to run Python in the candidate's own tab.
+ */
+const CDN = "https://cdn.jsdelivr.net";
+
+/**
+ * Content Security Policy.
+ *
+ * Written as a list rather than one long string because it was one long
+ * string, and a directive going missing in it is invisible until something
+ * breaks in a way that looks like a bug in the app.
+ *
+ * That already happened once. `script-src` allowed the CDN but `style-src`
+ * did not, so Monaco's JavaScript loaded while `editor.main.css` was refused.
+ * Monaco then rendered without the rules that position its hidden textarea and
+ * map clicks onto text — the textarea appeared as a plain, resizable form
+ * field over the code and the caret stopped following the mouse. It read as a
+ * broken editor, not as a blocked stylesheet, and it only failed in the
+ * browser, so no build or test caught it.
+ *
+ * **If a directive here needs the CDN, it needs it for every resource type
+ * Monaco and Pyodide fetch: script, style and font.** Monaco ships its icons
+ * as codicon.ttf from the same path, so tightening `font-src` alone would
+ * silently lose the editor's icons.
+ */
+const csp = [
+  "default-src 'self'",
+  "base-uri 'self'",
+  "object-src 'none'",
+  "frame-ancestors 'none'",
+  "form-action 'self'",
+  // 'unsafe-eval' is Monaco's; it compiles its own workers.
+  `script-src 'self' 'unsafe-inline' 'unsafe-eval' ${CDN}`,
+  // blob: is the Pyodide worker, which is created from a blob URL.
+  "worker-src 'self' blob:",
+  // The Go API and its WebSocket live on another origin in every environment.
+  "connect-src 'self' https: wss:",
+  `style-src 'self' 'unsafe-inline' ${CDN}`,
+  "img-src 'self' data: blob:",
+  `font-src 'self' data: https://fonts.gstatic.com ${CDN}`,
+].join("; ");
+
 const nextConfig: NextConfig = {
   async headers() {
-    return [{
-      source: "/(.*)",
-      headers: [
-        { key: "Content-Security-Policy", value: "default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'none'; form-action 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cdn.jsdelivr.net; worker-src 'self' blob:; connect-src 'self' https: wss:; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self' data: https://fonts.gstatic.com" },
-        { key: "X-Content-Type-Options", value: "nosniff" },
-        { key: "X-Frame-Options", value: "DENY" },
-        { key: "Referrer-Policy", value: "no-referrer" },
-        { key: "Permissions-Policy", value: "camera=(), microphone=(), geolocation=()" },
-        { key: "Strict-Transport-Security", value: "max-age=31536000; includeSubDomains" },
-      ],
-    }];
+    return [
+      {
+        source: "/(.*)",
+        headers: [
+          { key: "Content-Security-Policy", value: csp },
+          { key: "X-Content-Type-Options", value: "nosniff" },
+          { key: "X-Frame-Options", value: "DENY" },
+          { key: "Referrer-Policy", value: "no-referrer" },
+          { key: "Permissions-Policy", value: "camera=(), microphone=(), geolocation=()" },
+          { key: "Strict-Transport-Security", value: "max-age=31536000; includeSubDomains" },
+        ],
+      },
+    ];
   },
 };
 


### PR DESCRIPTION
Allow the CDN in the Next.js CSP for scripts, styles, and fonts so Monaco and Pyodide load correctly in browsers. This also rewrites the policy into a clearer directive list with comments explaining why each source is required, preventing the silent editor breakage caused by a missing stylesheet/font allowlist.