### PR TITLE
Add repo governance and issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,95 @@
+name: Bug report
+description: Something in SyncR does not work the way it should.
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Two questions up front, because they narrow this down faster than
+        anything else: **which side of the room were you on** (interviewer or
+        candidate), and **was anyone else connected** at the time. A lot of what
+        breaks here only breaks with two people in a room.
+
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened
+      description: What you saw, and what you expected instead.
+      placeholder: |
+        My cursor jumped to the top of the file every time the other person typed.
+        I expected my own cursor to stay where it was.
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: >
+        Numbered, from a fresh page load. If it needs two browsers, say which
+        one does what: "browser A creates the room, browser B opens the invite".
+      placeholder: |
+        1. Sign in and create a room
+        2. Open the invite link in a second browser
+        3. Type in browser B
+        4. Watch the caret in browser A
+    validations:
+      required: true
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Where does it happen
+      options:
+        - Interview room / live editing
+        - Running code
+        - Sign in, register or invite links
+        - Dashboard
+        - Admin or promotion codes
+        - Marketing pages
+        - Backend / API only
+        - Not sure
+    validations:
+      required: true
+
+  - type: dropdown
+    id: role
+    attributes:
+      label: Which side were you on
+      options:
+        - Interviewer (signed in, owns the room)
+        - Candidate (joined by invite link)
+        - Both browsers, testing alone
+        - Not applicable
+    validations:
+      required: true
+
+  - type: input
+    id: browser
+    attributes:
+      label: Browser and OS
+      placeholder: Chrome 141 on Windows 11
+    validations:
+      required: true
+
+  - type: textarea
+    id: console
+    attributes:
+      label: Console and network errors
+      description: >
+        Anything red from the browser console, and the Go server log lines if
+        you have them. A blocked resource, or a socket closing with 1006, is
+        usually the whole answer.
+      render: text
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Before filing
+      options:
+        - label: I searched the open issues and this is not one of them
+          required: true
+        - label: >
+            This is reproducible, or I have said clearly that it happened once
+            and I could not reproduce it
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,18 @@
+# Blank issues stay enabled. A template that does not fit is a reason to
+# abandon a report, and a badly-shaped issue about a real bug is worth much
+# more than a well-shaped one that never got filed.
+blank_issues_enabled: true
+
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/heshannethmina/SyncR/security/advisories/new
+    about: >
+      Please do not open a public issue. SyncR runs code a stranger typed and
+      guards an interview with bearer tokens, so report it privately here and
+      it can be fixed before it is described in public.
+  - name: Why is it built this way
+    url: https://github.com/heshannethmina/SyncR/blob/main/CLAUDE.md
+    about: >
+      Much of the reasoning is already written down: why one goroutine owns
+      each document, why tokens are not JWTs, why Python runs in the browser.
+      Worth a read before proposing a change to any of it.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,67 @@
+name: Feature request
+description: Propose something SyncR should be able to do.
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        SyncR is deliberately small: a shared editor, real execution, and the
+        thinnest thing around them that works. A proposal is far more likely to
+        land if it argues from **an interview that went badly without it** than
+        from a competitor's feature list.
+
+        Already decided against for now, and not for lack of interest:
+        video/audio, session recording and playback, auto-grading, and ATS
+        integrations. To reopen one of those, the case to make is that a real
+        pilot cannot proceed without it.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: The problem
+      description: >
+        What goes wrong today, and for whom. Concrete beats general: "the
+        candidate pasted a solution and I could not tell how much of it was
+        theirs" is actionable in a way that "better integrity tooling" is not.
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: What you would build
+      description: >
+        Roughly how it should work. If it needs a new WebSocket frame, say what
+        the frame carries and whether it is room state: anything the hub has to
+        keep must also appear in a late joiner's snapshot.
+    validations:
+      required: true
+
+  - type: dropdown
+    id: who
+    attributes:
+      label: Who is this for
+      options:
+        - Interviewers
+        - Candidates
+        - Both
+        - Whoever operates the deployment
+        - People contributing to the codebase
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: What you considered instead
+      description: >
+        Including doing nothing. Knowing what the workaround is says how urgent
+        this is far better than a priority field would.
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Before filing
+      options:
+        - label: I searched the open issues and this is not already proposed
+          required: true

--- a/.github/ISSUE_TEMPLATE/task.yml
+++ b/.github/ISSUE_TEMPLATE/task.yml
@@ -1,0 +1,39 @@
+name: Task or tech debt
+description: Work that is not a user-facing bug or feature. Refactors, tests, docs, infrastructure.
+labels: ["tech-debt"]
+body:
+  - type: textarea
+    id: what
+    attributes:
+      label: What needs doing
+    validations:
+      required: true
+
+  - type: textarea
+    id: why
+    attributes:
+      label: Why it is worth doing now
+      description: >
+        Tech debt is only worth paying down when it is costing something. Say
+        what it costs: a class of bug it keeps allowing, a change it makes
+        expensive, a check it stops us running.
+    validations:
+      required: true
+
+  - type: textarea
+    id: files
+    attributes:
+      label: Where in the codebase
+      description: Paths, and line numbers if you have them.
+      placeholder: |
+        backend/internal/ws/hub.go
+        web/components/RoomEditor.tsx:583
+
+  - type: textarea
+    id: done
+    attributes:
+      label: How we know it is done
+      description: >
+        Ideally a test that fails today. This repository leans on tests that pin
+        a decision in place; TestLaterJoinCannotExtendTheDeadline is the shape
+        to aim for.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,11 @@ updates:
     directory: /backend
     schedule:
       interval: weekly
+    # Conventional-commit prefix, so these pass the PR title check in
+    # .github/workflows/pr-title.yml. Dependabot titles its pull
+    # requests "Bump x from y to z" by default, which does not.
+    commit-message:
+      prefix: chore
     open-pull-requests-limit: 5
     groups:
       go-dependencies:
@@ -24,6 +29,11 @@ updates:
     directory: /web
     schedule:
       interval: weekly
+    # Conventional-commit prefix, so these pass the PR title check in
+    # .github/workflows/pr-title.yml. Dependabot titles its pull
+    # requests "Bump x from y to z" by default, which does not.
+    commit-message:
+      prefix: chore
     open-pull-requests-limit: 5
     groups:
       # Next, React and their types move together; splitting them produces
@@ -40,6 +50,11 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    # Conventional-commit prefix, so these pass the PR title check in
+    # .github/workflows/pr-title.yml. Dependabot titles its pull
+    # requests "Bump x from y to z" by default, which does not.
+    commit-message:
+      prefix: chore
     groups:
       actions:
         patterns: ["*"]

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,65 @@
+# Path-based labels for pull requests, applied by .github/workflows/labeler.yml.
+#
+# These say *where* a change landed, not what it is worth. "This touches the
+# hub" is a fact a glob can establish; "this is a bug" is not, and a bot that
+# guesses at the second kind produces labels nobody trusts.
+
+backend:
+  - changed-files:
+      - any-glob-to-any-file: backend/**
+
+frontend:
+  - changed-files:
+      - any-glob-to-any-file: web/**
+
+# The concurrent code. Called out separately from the rest of the backend
+# because a change here is the one that needs -race run against it and a
+# careful read of whether state is still owned by a single goroutine.
+websocket:
+  - changed-files:
+      - any-glob-to-any-file: backend/internal/ws/**
+
+database:
+  - changed-files:
+      - any-glob-to-any-file:
+          - backend/migrations/**
+          - backend/internal/store/**
+
+# Anything that changes how the app is built, run or deployed. A change here
+# can be green in CI and still break production, which is the reason it wants
+# its own label.
+infra:
+  - changed-files:
+      - any-glob-to-any-file:
+          - docker-compose*.yml
+          - render.yaml
+          - judge0.conf
+          - .github/**
+          - web/next.config.ts
+
+documentation:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "**/*.md"
+          - docs/**
+
+design:
+  - changed-files:
+      - any-glob-to-any-file:
+          - web/app/globals.css
+          - web/public/**
+
+testing:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "**/*_test.go"
+          - "**/*.test.ts"
+          - "**/*.test.tsx"
+
+dependencies:
+  - changed-files:
+      - any-glob-to-any-file:
+          - backend/go.mod
+          - backend/go.sum
+          - web/package.json
+          - web/package-lock.json

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,41 @@
+## What this changes
+
+<!-- One or two sentences. The title carries the summary; this is for the
+     reasoning that will not fit in it. -->
+
+Closes #
+
+## Why
+
+<!-- What was wrong before. If this reverses a decision written down in
+     CLAUDE.md, say so explicitly and say why: several of those choices look
+     like accidents and are not. -->
+
+## How it was verified
+
+<!-- Delete what does not apply. CI already runs the Go suite with -race, tsc,
+     eslint and a Next build on every pull request, so this section is for what
+     CI cannot do: what you actually clicked. -->
+
+- [ ] `cd backend && go test ./...`
+- [ ] Store tests against a real Postgres (`TEST_DATABASE_URL=...`)
+- [ ] `cd web && npx tsc --noEmit && npm run lint`
+- [ ] Opened a room in **two browsers** and confirmed live sync still works
+- [ ] Checked the candidate path through an invite link, not just the interviewer's
+
+## Notes for the reviewer
+
+<!-- Anything you are unsure about, or deliberately left out. -->
+
+---
+
+<!-- Two things that are easy to trip over here, kept in the template because
+     they are cheap to check and expensive to miss:
+
+     * If you touched backend/internal/ws, run the race detector before
+       pushing. A race there passes on an idle laptop and fails on a busy CI
+       runner: GOMAXPROCS=2 go test -race -count=30 ./internal/ws/
+
+     * If you added shared room state, it has to appear in the snapshot a late
+       joiner receives, or the second person in the room sees a different room
+       from the first. -->

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,82 @@
+# CodeQL — static analysis for security-relevant bugs.
+#
+# This is the bot that reads the code looking for the classes of mistake that
+# tests do not catch: an unsanitised path joined from user input, a token
+# compared with ==, a query built by concatenation. It reports into the
+# Security tab rather than failing a pull request outright, because a finding
+# here is something to read and judge, not something to block a merge on.
+#
+# Separate from CI on purpose, for the same reason govulncheck is separate:
+# a newly published query firing on old code must not hide a real test
+# regression behind it.
+
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  # A weekly run matters more than it looks. CodeQL ships new queries
+  # continuously, so code that was clean in January can have a finding in
+  # March without a single line changing.
+  schedule:
+    - cron: "23 5 * * 1"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    permissions:
+      # Writing the findings into the Security tab is the whole point.
+      security-events: write
+      contents: read
+      actions: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # Go is compiled, so CodeQL needs a real build to see the code.
+          # autobuild finds backend/go.mod on its own.
+          - language: go
+            build-mode: autobuild
+          # The Next.js app is interpreted; there is nothing to build, and
+          # asking for one only means waiting on a Next compile for no
+          # additional coverage.
+          - language: javascript-typescript
+            build-mode: none
+
+    steps:
+      - name: Check out
+        uses: actions/checkout@v4
+
+      # Pinned to the same version CI uses, so a Go release cannot make the
+      # analysis job disagree with the test job about what compiles.
+      - name: Set up Go
+        if: matrix.language == 'go'
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: backend/go.mod
+          cache-dependency-path: backend/go.sum
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+          # security-extended adds the lower-confidence security queries.
+          # Worth the extra noise on a project that hands a stranger an
+          # editor and runs what they type.
+          queries: security-extended
+
+      - name: Analyze
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: /language:${{ matrix.language }}

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,39 @@
+# Labels a pull request by the paths it touches, from .github/labeler.yml.
+#
+# Small, but it is what makes the issue list filterable a year from now: with
+# a label on every pull request, "what has changed in the hub lately" is a
+# query rather than an afternoon of scrolling.
+
+name: Labeler
+
+# pull_request_target, not pull_request, and the distinction matters.
+#
+# A pull request from a fork — which is how any outside contribution arrives —
+# gets a read-only token under `pull_request`, so the labelling silently does
+# nothing. `pull_request_target` runs the workflow from the *base* branch with
+# a writable token.
+#
+# That is normally the dangerous choice, because a workflow running with write
+# access must never check out and execute a fork's code. This one is safe
+# because it never checks anything out: actions/labeler reads the changed-file
+# list from the API and applies labels. Nothing from the fork is executed. If
+# a step is ever added here that runs the contributor's code, this trigger has
+# to change with it.
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@v5
+        with:
+          # Labels are added, never removed. Someone who labels a pull
+          # request by hand has made a decision, and a bot undoing it on the
+          # next push is how people stop labelling anything.
+          sync-labels: false

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,52 @@
+# Checks that a pull request title is a conventional commit.
+#
+# Squash merging is enabled and the squash message defaults to the pull
+# request title, so on any branch with more than one commit the title *is*
+# what lands on main. That makes it the one place the convention can be
+# enforced — a tidy branch history disappears at squash time.
+#
+# This fails the check rather than rewriting the title. A bot editing somebody
+# else's words is worse than telling them what to change.
+
+name: PR title
+
+on:
+  pull_request_target:
+    types: [opened, edited, reopened, synchronize]
+
+permissions:
+  pull-requests: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            feat
+            fix
+            perf
+            refactor
+            docs
+            test
+            build
+            ci
+            chore
+            revert
+          # Optional, and left free-form rather than pinned to a list. A
+          # scope allowlist has to be edited every time a package is added,
+          # and gets stale rather than enforced.
+          requireScope: false
+          # "fix: Handle empty snapshot" reads the same as the lowercase
+          # form and rejecting it teaches nothing.
+          subjectPattern: ^(?![A-Z]).+$
+          subjectPatternError: |
+            The subject "{subject}" should start lowercase — "{type}: handle …",
+            not "{type}: Handle …".

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,66 @@
+# The stale bot — closes what has genuinely been abandoned, and nothing else.
+#
+# A backlog nobody prunes stops being a backlog: after a year of "open, no
+# comment since March" it is impossible to tell what is still wanted from what
+# was an idea somebody had once. This marks the quiet ones and closes them if
+# they stay quiet, which keeps the open list something a person can actually
+# read top to bottom.
+#
+# The exemptions are the important half of the config. A bot that closes real
+# work because nobody happened to comment on it is worse than no bot at all,
+# so anything deliberately parked, anything on a milestone, and anything
+# labelled as security or a pinned decision is left alone forever.
+
+name: Stale
+
+on:
+  schedule:
+    - cron: "17 3 * * *"
+  # Manually runnable, so the effect of a config change can be seen without
+  # waiting a day for the cron.
+  workflow_dispatch:
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          days-before-issue-stale: 90
+          days-before-issue-close: 21
+          stale-issue-label: stale
+          stale-issue-message: >
+            This has had no activity for 90 days, so it is being marked stale.
+            If it is still wanted, say so — a comment, or any label change,
+            clears this. Otherwise it will close in 21 days. Closing is not a
+            judgement on the idea; a closed issue can be reopened.
+
+          # Pull requests get a shorter fuse than issues. An idea can sit for
+          # a quarter and still be a good idea; a branch that has not moved in
+          # a month has usually been superseded by main.
+          days-before-pr-stale: 30
+          days-before-pr-close: 14
+          stale-pr-label: stale
+          stale-pr-message: >
+            No activity for 30 days. If this is still in progress, push
+            something or leave a comment and the label clears. Otherwise it
+            will close in 14 days — the branch is not deleted, so reopening
+            costs nothing.
+
+          # Never touched, whatever happens.
+          exempt-issue-labels: "security,roadmap,pinned,help wanted,good first issue"
+          exempt-pr-labels: "security,pinned"
+          # Anything on a milestone has been scheduled by a human. That
+          # decision outranks a timer.
+          exempt-all-milestones: true
+          # Dependabot's own pull requests are handled by Dependabot.
+          exempt-pr-author: dependabot[bot]
+
+          # Ascending, so the oldest — the ones this exists for — are
+          # processed first if the API budget runs out mid-run.
+          ascending: true
+          operations-per-run: 60

--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,5 @@ Thumbs.db
 .idea/
 *.swp
 
-
 #Security Test
 SECURITY.MD

--- a/README.md
+++ b/README.md
@@ -1,205 +1,64 @@
-# SyncR
+<div align="center">
+  <img src="web/public/syncr-logo.png" alt="SyncR" width="260" />
 
-[![CI](https://github.com/heshannethmina/SyncR/actions/workflows/ci.yml/badge.svg)](https://github.com/heshannethmina/SyncR/actions/workflows/ci.yml)
+  <p><strong>A focused, real-time code interview workspace.</strong></p>
 
-A collaborative code editor for technical interviews. An interviewer creates a
-room and sends a link; the candidate opens it and starts typing. Both sides see
-the same document live, and code runs for real in a sandbox.
+  <p>
+    <a href="https://github.com/heshannethmina/SyncR/actions/workflows/ci.yml"><img src="https://github.com/heshannethmina/SyncR/actions/workflows/ci.yml/badge.svg" alt="CI status" /></a>
+    <a href="#contributing">Contribute</a>
+  </p>
+</div>
 
-Built as a leaner alternative to CoderPad and HackerRank, for startups, small
-teams and university placement programmes.
+## What is SyncR?
 
-- **Frontend** — Next.js (App Router) + TypeScript + Tailwind, Monaco editor
-- **Backend** — Go: a hand-built WebSocket hub, one goroutine per room owning
-  that room's document, plus a REST API
-- **Storage** — PostgreSQL for users, sessions and rooms
-- **Execution** — Judge0, in its own containers, never in the Go process
+SyncR makes technical interviews feel natural: an interviewer creates a room, shares an invite link, and collaborates with a candidate in the same code editor in real time. Candidates can join from their browser—no installation or account required.
 
-`CLAUDE.md` holds the detailed architecture notes and the reasoning behind the
-decisions that are easy to undo by accident. Read it before changing the hub,
-the auth model, or the design system.
+It is designed for startups, hiring teams, and university placement programmes that want a lightweight alternative to larger interviewing platforms.
 
-## Running locally
+## Product highlights
 
-```bash
-# 1. Application database — users, sessions, rooms
-docker compose -f docker-compose.app.yml up -d --wait
+- Live shared code editing with room-based invite links
+- Browser-based coding workspace powered by the Monaco editor
+- Multi-language code execution via Judge0 when an execution service is connected
+- Interview dashboard for creating and managing rooms
+- Secure accounts, sessions, and room access
+- Admin tools for promotion codes and account plans
 
-# 2. Backend — WebSocket hub + REST on :8080. Migrations run at startup.
-cd backend && go run ./cmd/server
+## Built with
 
-# 3. Frontend — http://localhost:3000
-cd web && npm install && npm run dev
-```
+| Area | Technologies |
+| --- | --- |
+| Frontend | Next.js, React, TypeScript, Tailwind CSS, Monaco Editor |
+| Backend | Go, Gorilla WebSocket |
+| Data | PostgreSQL |
+| Code execution | Judge0 |
+| Deployment | Vercel and Render |
+| Quality | GitHub Actions, ESLint, Go tests |
 
-Then open http://localhost:3000/register, create an account, and make a room.
+## Repository guide
 
-### Code execution (optional, and not possible on Windows)
+| Path | Purpose |
+| --- | --- |
+| `web/` | Next.js application and the product interface |
+| `backend/` | Go API, WebSocket collaboration service, and data layer |
+| `docs/` | Project documentation and route map |
+| `.github/` | Automated checks and dependency maintenance |
 
-```bash
-docker compose up -d          # Judge0 — a 14.1GB image, be patient
-curl http://localhost:2358/about
-```
+## Contributing
 
-**Judge0 cannot execute anything on Docker Desktop for Windows.** It sandboxes
-with isolate 1.8.1, which speaks only cgroup v1, and Docker Desktop's WSL2 VM
-is cgroup v2 only — every submission returns `Internal Error`. It needs an
-amd64 Linux host with cgroup v1 (Ubuntu 20.04 by default; on 22.04+ set
-`GRUB_CMDLINE_LINUX="systemd.unified_cgroup_hierarchy=0"` and reboot). The full
-diagnosis, and the four workarounds that do not work, are in `CLAUDE.md`.
+Contributions, bug reports, and product ideas are welcome.
 
-Without it the app runs fine; the Run button returns 502.
+1. Check existing issues or open one to discuss a substantial change.
+2. Fork the repository and create a focused branch.
+3. Keep each pull request small, clear, and accompanied by relevant tests.
+4. Describe the user-facing impact in the pull request and link the related issue when there is one.
 
-### Tests
+Before opening a pull request, please make sure the relevant frontend or backend checks pass. The automated CI workflow will validate both parts of the project again.
 
-```bash
-cd backend
-go test ./...
+## Community
 
-# Store tests need a real Postgres and skip without this
-TEST_DATABASE_URL='postgres://syncr:syncrdev@localhost:5433/syncr' \
-  go test ./internal/store/
+If you would like to help, a great place to start is improving the interface, documentation, accessibility, tests, or interview workflows. Please be kind, specific, and collaborative in issues and pull requests.
 
-# The race detector needs CGO and a gcc — see CLAUDE.md for the local path
-CGO_ENABLED=1 go test -race ./...
-```
+---
 
-## Becoming the admin
-
-Set **`OWNER_EMAILS`** on the backend service to your own address:
-
-```
-OWNER_EMAILS=you@example.com
-```
-
-On Render that is Environment -> Add Environment Variable on the `syncr-api`
-service, then Save (which redeploys). Comma-separate for more than one.
-
-That address then gets unlimited interviews and an **Admin** link in the
-dashboard header, with **nothing written to the database** — which is the
-point. An `is_admin` column could only be set by somebody who can already
-write to the database, and Render grants neither a shell nor a SQL console on
-the free tier. It also survives the free Postgres expiring and taking every
-row with it.
-
-Leave it unset and nobody is an admin, which is the right default.
-
-From `/admin` you can issue and revoke promotion codes, see who claimed each
-one, and change any account's plan — no SQL for any of it.
-
-## Giving somebody free access
-
-Pilot customers, universities and anyone being shown the product get a
-promotion code instead of a subscription. They register, enter it under
-**Have a promotion code?** on their interviews page, and their limits lift.
-
-The admin UI at `/admin` is the normal way to issue one. If you would rather
-do it in SQL, or need to before you have set `OWNER_EMAILS`:
-
-```sql
--- unlimited interviews and unlimited length, for 25 people, no end date
-INSERT INTO promo_codes (code, plan, max_redemptions, note)
-VALUES ('SYNCR-PILOT', 'unlimited', 25, 'launch pilot');
-
--- 90 days of Pro, claimable once
-INSERT INTO promo_codes (code, plan, max_redemptions, grant_days, note)
-VALUES ('UNI-CS-2026', 'pro', 1, 90, 'placement office');
-```
-
-`max_redemptions` of 0 means no ceiling; a NULL `grant_days` means the grant
-never lapses; `expires_at` bounds the *code* rather than the grant. Codes are
-matched upper-cased and with whitespace stripped, so `syncr-pilot` works.
-
-Who has claimed what:
-
-```sql
-SELECT r.code, u.email, r.redeemed_at
-FROM promo_redemptions r JOIN users u ON u.id = r.user_id
-ORDER BY r.redeemed_at DESC;
-```
-
-Deleting a code stops new claims but leaves grants already given, on purpose.
-To take those back as well:
-
-```sql
-UPDATE users SET promo_plan = NULL, promo_expires_at = NULL
-WHERE promo_code = 'SYNCR-PILOT';
-```
-
-## Continuous integration
-
-`.github/workflows/ci.yml` runs on every pull request, and on pushes to
-`main`. Not on every push to every branch: a branch with an open pull request
-would build twice for one result, and the branch ruleset makes the pull
-request the check that counts. Pushes to `main` still build, because the merge
-commit is the thing that deploys and no pull request tested it as such.
-Three jobs, in parallel:
-
-| Job | Runs |
-|---|---|
-| **Go** | `gofmt` check, `go vet`, `go build`, `go test -race ./...` |
-| **Next.js** | `npm ci`, `tsc --noEmit`, `eslint`, `next build` |
-| **govulncheck** | reachable vulnerabilities in Go dependencies |
-
-Two of these are stronger in CI than they can be locally:
-
-- **`-race` always runs.** It needs CGO and a gcc, which on Windows means
-  installing mingw-w64 by hand and exporting `PATH` first — so locally it gets
-  run occasionally. A Linux runner has a toolchain already.
-- **The store tests never skip.** They need a real Postgres and skip without
-  `TEST_DATABASE_URL`; CI provides one as a service container. Because that
-  container is new every run, **the migrations are applied to an empty schema
-  every time**, which is the one thing a local run never checks.
-
-Dependabot (`.github/dependabot.yml`) opens grouped weekly update pull
-requests for Go, npm and the actions themselves, so every upgrade goes through
-the suite above before anyone looks at it.
-
-A branch ruleset on `main` requires `Go`, `Next.js` and `govulncheck` to pass
-before a pull request can merge, so a red run cannot reach `main` in the first
-place. Two things it does not cover: pushes made with a bypass, and the gap
-between merging and deploying — Render and Vercel build straight from the push
-to `main`, so a merge is a deploy. Render's service settings can additionally
-wait for checks.
-
-## Deploying
-
-The two halves deploy separately: **Vercel** for the frontend, **Render** for
-the Go backend and Postgres. `render.yaml` describes the backend half.
-
-Order matters, because each side needs the other's URL.
-
-**1. Render** — New → Blueprint → this repository. It creates `syncr-api` and a
-free `syncr-db` from `render.yaml`. Set `CORS_ORIGIN=*` for now. Wait for the
-first deploy; the schema creates itself, since migrations run at startup. Note
-the URL, e.g. `https://syncr-api.onrender.com`.
-
-**2. Vercel** — import the same repository and **set the Root Directory to
-`web`**. The repo root is not the Next.js app, and this is the step that is
-easy to miss. Add:
-
-```
-NEXT_PUBLIC_API_URL=https://syncr-api.onrender.com
-NEXT_PUBLIC_WS_URL=wss://syncr-api.onrender.com
-```
-
-Deploy, and note the URL.
-
-**3. Render again** — set `CORS_ORIGIN` to the Vercel production URL. That one
-variable gates both REST CORS and the WebSocket origin check, so it is what
-admits the browser to the socket. It is comma-separated; add Vercel preview
-origins too if you want branch deploys to work.
-
-`NEXT_PUBLIC_*` values are baked in at build time, so changing them later needs
-a Vercel redeploy, not just a settings save.
-
-### What the free tier costs you
-
-| | |
-|---|---|
-| Postgres | **Expires 30 days after creation.** Accounts and rooms go with it. Upgrading that one database is the whole fix. |
-| Web service | Sleeps after 15 minutes idle, ~1 minute to wake. An active interview keeps it awake. |
-| Run button | Returns 502. Judge0 cannot run on any PaaS — no privileged containers. |
-
-Everything else works: accounts, rooms, shareable candidate links, live
-collaborative editing and presence.
+Built for better technical conversations.


### PR DESCRIPTION
Introduces GitHub issue templates for bugs, features, and tasks, adds PR labeling and title checks, and configures stale/CodeQL automation. It also sets Dependabot to use conventional-commit prefixes and refreshes the README and repo metadata to make contribution and maintenance flow clearer without changing product behavior.