### PR TITLE
chore: add triage automation and community docs

### DIFF
--- a/.github/DISCUSSION_TEMPLATE/design-proposals.yml
+++ b/.github/DISCUSSION_TEMPLATE/design-proposals.yml
@@ -1,0 +1,121 @@
+labels: ["Proposal/Draft"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        For anything that changes the WebSocket protocol, the database schema,
+        the authorization model, or the concurrency design. Writing it down here
+        is much cheaper than discovering in review that the approach was wrong.
+
+        Read the relevant part of
+        [`CLAUDE.md`](https://github.com/heshannethmina/SyncR/blob/main/CLAUDE.md)
+        first. If this proposal reverses a decision recorded there, say so
+        explicitly — several of those choices look like accidents and are not,
+        and a proposal that argues against one on its merits is welcome.
+
+        Label it `Proposal/Review` when it is ready for feedback.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: >
+        What goes wrong today, for whom, and what it costs. Concrete beats
+        general — an interview that went badly is a better argument than a
+        category of concern.
+    validations:
+      required: true
+
+  - type: textarea
+    id: existing
+    attributes:
+      label: How this is solved elsewhere
+      description: >
+        CoderPad, HackerRank, Codility, or any editor with live collaboration.
+        Include the current workaround, if there is one. Knowing what people do
+        today says how urgent this is.
+    validations:
+      required: false
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed design
+      value: |
+        ### Overview
+
+        ### Protocol changes
+        <!-- New or changed frame types. For each: what it carries, which role
+             may send it, and whether it is room state. Anything the hub keeps
+             must also appear in a late joiner's snapshot. -->
+
+        ### Schema changes
+        <!-- New tables or columns, and the migration. Migrations are one-way:
+             one that has run in production can only be followed, not edited. -->
+
+        ### API surface
+        <!-- New or changed REST routes, and what authorizes each. -->
+
+        ### Out of scope
+        <!-- What this deliberately does not cover. -->
+    validations:
+      required: true
+
+  - type: textarea
+    id: concurrency
+    attributes:
+      label: Effect on the hub
+      description: >
+        Required if this touches `internal/ws`, and worth a line either way.
+      value: |
+        - Does any state become shared between goroutines? If so, which
+          goroutine owns it?
+        - Does this add a second message that must arrive with a join? Two sends
+          into the same `select` have no defined order — that has already caused
+          one race here, and the fix was to carry the value on the `Client`.
+        - What test pins the new behaviour?
+    validations:
+      required: false
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Including doing nothing.
+      placeholder: |
+        | Approach | Trade-off | Why not |
+        |----------|-----------|---------|
+        |          |           |         |
+    validations:
+      required: false
+
+  - type: textarea
+    id: risks
+    attributes:
+      label: Risks and what could go wrong
+      description: >
+        Especially anything that fails *only in a browser*. A blocked stylesheet
+        once made Monaco look like a stuck cursor while `tsc`, eslint, the Next
+        build and CI were all green — so "how would we notice this broke" is a
+        real question here.
+    validations:
+      required: false
+
+  - type: textarea
+    id: open-questions
+    attributes:
+      label: Open questions
+      placeholder: |
+        - [ ]
+    validations:
+      required: false
+
+  - type: textarea
+    id: plan
+    attributes:
+      label: Implementation plan
+      description: >
+        The issues this becomes, roughly in order, and which milestone they
+        belong to. Note anything that has to land first.
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -3,6 +3,8 @@
 # more than a well-shaped one that never got filed.
 blank_issues_enabled: true
 
+# These appear on the new-issue page, so they are the last chance to divert
+# something that does not belong in the issue tracker before it is filed there.
 contact_links:
   - name: Security vulnerability
     url: https://github.com/heshannethmina/SyncR/security/advisories/new
@@ -10,6 +12,22 @@ contact_links:
       Please do not open a public issue. SyncR runs code a stranger typed and
       guards an interview with bearer tokens, so report it privately here and
       it can be fixed before it is described in public.
+  - name: Question — how do I, why does it
+    url: https://github.com/heshannethmina/SyncR/discussions/categories/q-a
+    about: >
+      Ask in Q&A rather than filing an issue. An issue should have an answer
+      to "how would we know this is done"; a question does not yet.
+  - name: Half-formed idea
+    url: https://github.com/heshannethmina/SyncR/discussions/categories/ideas
+    about: >
+      Somewhere to think out loud before it is scoped. Ideas that survive
+      become feature issues, or design proposals if they need agreement first.
+  - name: Design proposal
+    url: https://github.com/heshannethmina/SyncR/discussions/categories/design-proposals
+    about: >
+      For anything changing the WebSocket protocol, the schema, the
+      authorization model or the concurrency design. Writing it down beats
+      finding out in review that the approach was wrong.
   - name: Why is it built this way
     url: https://github.com/heshannethmina/SyncR/blob/main/CLAUDE.md
     about: >

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,91 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+**Please do not open a public issue.**
+
+Report it privately through GitHub's advisory form:
+
+**https://github.com/heshannethmina/SyncR/security/advisories/new**
+
+That creates a draft advisory only you and the maintainers can see, so a fix can
+be prepared before the problem is described in public.
+
+If you would rather not use GitHub, email the address in the repository owner's
+GitHub profile and say "SyncR security" in the subject.
+
+## What to expect
+
+SyncR is maintained by one person, so please read these as honest estimates
+rather than a service commitment:
+
+| | |
+|---|---|
+| Acknowledgement | within 5 days |
+| Assessment, and a rough fix timeline | within 14 days |
+| Credit | in the advisory, unless you ask otherwise |
+
+If you have had no reply after two weeks, assume the message was missed and
+send it again rather than concluding it was ignored.
+
+## Why this matters more than the size of the project suggests
+
+SyncR does several things that are ordinarily considered dangerous, because the
+product does not work otherwise:
+
+- **It runs code that a stranger typed.** That is the entire point of it.
+- **It holds session tokens in `localStorage`**, not in an HttpOnly cookie. That
+  is a considered trade — the web app and the API are separate origins in every
+  environment, so a cookie would need `SameSite=None; Secure` and break local
+  development outright — but it does mean any XSS is also session theft.
+- **An invite link admits an anonymous person to a room.** Anyone holding the
+  link is in; candidates deliberately have no account.
+- **Candidate paste content is captured** and kept in the room's hub. That is
+  real text typed by a real person, so exposing it is a privacy incident and not
+  only a bug.
+
+A finding in any of those areas is worth reporting even if it looks minor.
+
+## In scope
+
+- The deployed application and its API.
+- This repository: the Go backend, the Next.js app, the deployment
+  configuration, and the GitHub Actions workflows.
+- Dependencies, where SyncR's use of them is what creates the problem.
+
+## Not vulnerabilities
+
+Two categories come up often enough to name:
+
+**The interview-integrity signals are detection only, and documented as
+defeatable.** SyncR reports when a candidate switches tab or pastes. A browser
+cannot prevent either — there is no API for it, deliberately — and anyone can
+use a phone or a second machine. "I opened another tab and it did not stop me"
+is the design, not a bug. So is under-reporting an away duration: the client
+times its own absence, because timing it server-side would be meaningless
+across a reconnect.
+
+**Python output is not verified.** Python runs in the candidate's own browser
+through Pyodide, so a determined candidate could alter the result before it is
+shared. This is a deliberate trade: on a managed host there is no sandbox
+available, and running the code in the candidate's own tab means there is
+nothing of ours near it. In a live interview someone is watching. Verified
+execution means Judge0 on a real Linux host, which is a deployment task.
+
+Both are written up at more length in `CLAUDE.md`.
+
+## Please do not
+
+- Test against live interview rooms that are not yours. There may be a real
+  candidate in one, being assessed for a real job.
+- Run denial-of-service or load tests against the deployed instance.
+- Access, modify or keep other people's data. If you stumble into some, stop and
+  say so in the report.
+
+Testing against your own local deployment is unrestricted, and is the best way
+to look at any of this.
+
+## Supported versions
+
+There is one version: whatever is on `main` and deployed. There are no
+maintained release branches and no backports.

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -1,0 +1,176 @@
+# Opening triage — puts a new issue into a state a human can sort, without
+# waiting for one to be available.
+#
+# Two jobs, deliberately separate because they answer different questions:
+#
+#   * `needs-triage` marks that nobody has decided how urgent this is. It is
+#     removed automatically the moment a Priority label appears, so the label
+#     means "still unsorted" rather than "was once unsorted".
+#   * The area labels come from the issue form's own dropdown. The reporter
+#     already told us where the problem is; asking a maintainer to re-read the
+#     body and apply the matching label is work a regular expression can do.
+#
+# What this deliberately does NOT do is guess at Type or Priority. A glob can
+# establish which files a change touches and a dropdown can establish what the
+# reporter believes; neither can establish how much a problem matters, and a
+# bot that guesses at that produces labels nobody trusts.
+
+name: Triage
+
+on:
+  issues:
+    types: [opened, edited, labeled, unlabeled]
+
+permissions:
+  issues: write
+
+jobs:
+  # ---------------------------------------------------------------------------
+  needs-triage:
+    name: Mark or clear needs-triage
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const issue = context.payload.issue;
+
+            // Pull requests also arrive through the issues API. They are not
+            // triaged this way — the labeler handles them by path.
+            if (issue.pull_request) {
+              core.info('Payload is a pull request; skipping.');
+              return;
+            }
+
+            const { owner, repo } = context.repo;
+            const names = (issue.labels || []).map(
+              (l) => (typeof l === 'string' ? l : l.name || '')
+            );
+
+            const hasPriority = names.some((n) => n.startsWith('Priority/'));
+            const hasNeedsTriage = names.includes('needs-triage');
+
+            // A priority has been set, so the issue is triaged by definition.
+            if (hasPriority && hasNeedsTriage) {
+              core.info('Priority present; removing needs-triage.');
+              await github.rest.issues.removeLabel({
+                owner, repo, issue_number: issue.number, name: 'needs-triage',
+              });
+              return;
+            }
+
+            // No priority and not yet flagged: flag it.
+            if (!hasPriority && !hasNeedsTriage) {
+              core.info('No priority; adding needs-triage.');
+              await github.rest.issues.addLabels({
+                owner, repo, issue_number: issue.number, labels: ['needs-triage'],
+              });
+              return;
+            }
+
+            core.info('Nothing to change.');
+
+  # ---------------------------------------------------------------------------
+  area-labels:
+    name: Apply area labels from the form
+    # Only on open and edit. A label change cannot alter the body, so re-running
+    # this on every `labeled` event would re-add a label a maintainer had just
+    # deliberately removed.
+    if: github.event.action == 'opened' || github.event.action == 'edited'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const issue = context.payload.issue;
+            if (issue.pull_request) return;
+
+            const body = issue.body || '';
+            if (!body.trim()) {
+              core.info('Empty body — a blank issue, nothing to parse.');
+              return;
+            }
+
+            const { owner, repo } = context.repo;
+
+            // An issue form renders each answer as a markdown section:
+            //
+            //   ### Where does it happen
+            //
+            //   Interview room / live editing
+            //
+            // The heading text is the `label:` field from the template, so
+            // these two strings must stay in step with
+            // .github/ISSUE_TEMPLATE/bug_report.yml. If a heading is renamed
+            // there and not here, this quietly stops labelling anything —
+            // which is why the run logs when it finds no section.
+            const HEADINGS = ['Where does it happen', 'Who is this for'];
+
+            function sectionFor(heading) {
+              const escaped = heading.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+              const re = new RegExp(
+                `###\\s*${escaped}\\s*\\n([\\s\\S]*?)(?=\\n###\\s|$)`
+              );
+              const m = body.match(re);
+              return m ? m[1].trim() : '';
+            }
+
+            // The dropdown answers, mapped to the labels this repository
+            // actually uses. Several answers map to more than one label
+            // because a room bug is usually both halves at once.
+            const MAP = {
+              'Interview room / live editing': ['frontend', 'websocket'],
+              'Running code':                  ['frontend', 'backend'],
+              'Sign in, register or invite links': ['backend', 'security'],
+              'Dashboard':                     ['frontend'],
+              'Admin or promotion codes':      ['backend'],
+              'Marketing pages':               ['frontend', 'design'],
+              'Backend / API only':            ['backend'],
+              'Whoever operates the deployment': ['infra'],
+              'People contributing to the codebase': ['tech-debt'],
+              // "Not sure", "Interviewers", "Candidates" and "Both" say
+              // nothing about where the code is, so they map to nothing.
+            };
+
+            const answers = [];
+            for (const heading of HEADINGS) {
+              const section = sectionFor(heading);
+              if (!section) {
+                core.info(`No section found for "${heading}".`);
+                continue;
+              }
+              if (section === '_No response_') continue;
+              // Multi-select dropdowns are comma-separated.
+              for (const part of section.split(',')) {
+                const a = part.trim();
+                if (a) answers.push(a);
+              }
+            }
+
+            const toApply = new Set();
+            for (const a of answers) {
+              for (const label of MAP[a] || []) toApply.add(label);
+            }
+
+            // Skip labels already present, so an edit does not make a
+            // pointless API call.
+            //
+            // Note what this does NOT do: if a maintainer removes an area
+            // label and the reporter later edits the body, it comes back. The
+            // alternative is running on `opened` only, which loses the case
+            // this is mostly for — a reporter fixing a dropdown they got
+            // wrong. Re-adding is the less annoying of the two.
+            const existing = new Set(
+              (issue.labels || []).map((l) => (typeof l === 'string' ? l : l.name))
+            );
+            const labels = [...toApply].filter((l) => !existing.has(l));
+
+            if (labels.length === 0) {
+              core.info('No new area labels to apply.');
+              return;
+            }
+
+            core.info(`Applying: ${labels.join(', ')}`);
+            await github.rest.issues.addLabels({
+              owner, repo, issue_number: issue.number, labels,
+            });

--- a/.gitignore
+++ b/.gitignore
@@ -28,5 +28,11 @@ Thumbs.db
 .idea/
 *.swp
 
-#Security Test
-SECURITY.MD
+# Security Test — a local penetration-testing brief, not a policy.
+#
+# Anchored with a leading slash so it ignores ONLY the file at the repository
+# root. Without the slash the pattern matches at any depth, and because git is
+# case-insensitive on Windows (core.ignorecase=true) it silently swallowed
+# .github/SECURITY.md — the public security policy — which then could not be
+# committed and gave no error saying why.
+/SECURITY.MD

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,129 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity
+and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the
+  overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or
+  advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email
+  address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+the project maintainer, [@heshannethmina](https://github.com/heshannethmina),
+via the email address on their GitHub profile.
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series
+of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or
+permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior,  harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within
+the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.0, available at
+https://www.contributor-covenant.org/version/2/0/code_of_conduct.html.
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct
+enforcement ladder](https://github.com/mozilla/diversity).
+
+[homepage]: https://www.contributor-covenant.org
+
+For answers to common questions about this code of conduct, see the FAQ at
+https://www.contributor-covenant.org/faq. Translations are available at
+https://www.contributor-covenant.org/translations.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,220 @@
+# Contributing to SyncR
+
+Thanks for looking. This document is the practical half: how to get SyncR
+running, what the checks expect, and where a conversation belongs.
+
+The *reasoning* behind the design lives in [`CLAUDE.md`](CLAUDE.md) — why one
+goroutine owns each document, why tokens are not JWTs, why Python runs in the
+browser. It is worth reading before proposing a change to any of that. Several
+things in this codebase look like accidents and are not.
+
+---
+
+## Where things go
+
+| | Use |
+|---|---|
+| A bug, with steps to reproduce | **Issue** |
+| A concrete, scoped feature request | **Issue** |
+| A task or piece of tech debt | **Issue** |
+| "How do I…", "why does it…" | **Discussion → Q&A** |
+| A half-formed idea | **Discussion → Ideas** |
+| A design that needs agreement before code | **Discussion → Design Proposals** |
+| A security vulnerability | **[Private advisory](https://github.com/heshannethmina/SyncR/security/advisories/new)**, never an issue |
+
+The rule of thumb: an issue should have an answer to "how would we know this is
+done". If it does not yet, it is a discussion.
+
+### Design proposals
+
+Anything that changes the WebSocket protocol, the database schema, the
+authorization model, or the concurrency design should start as a **Design
+Proposal** discussion rather than as a pull request. Writing it down first is
+cheaper than discovering in review that the approach was wrong.
+
+Proposals move through labels: `Proposal/Draft` → `Proposal/Review` →
+`Proposal/Approved` → `Proposal/Implemented` (or `Proposal/Rejected`). Once
+approved, open issues for the implementation and link them back to the
+discussion.
+
+---
+
+## Getting it running
+
+You need **Go**, **Node 20+**, and **Docker**. You do not need Judge0 — see the
+warning below.
+
+### 1. The application database
+
+```bash
+docker compose -f docker-compose.app.yml up -d --wait
+```
+
+**Note the `-f`.** Plain `docker compose up` starts the *Judge0* stack, which is
+a different thing entirely with its own Postgres. Starting the wrong one is the
+most common way to end up confused about why nothing works.
+
+Postgres binds **5433** locally, not 5432, so it does not collide with a
+Postgres you may already be running. CI uses 5432, where there is nothing to
+collide with.
+
+### 2. The backend
+
+```bash
+cd backend && go run ./cmd/server
+```
+
+Listens on `:8080`. Migrations run automatically at startup, so an empty
+database populates itself.
+
+### 3. The frontend
+
+```bash
+cd web && npm ci && npm run dev
+```
+
+Listens on `:3000`. Use `npm ci`, not `npm install` — it fails when
+`package.json` and the lockfile disagree, which is what keeps everyone on the
+same dependency tree.
+
+### Judge0 does not work on Docker Desktop for Windows
+
+Do not spend a day on this. Judge0 1.13.x sandboxes with isolate 1.8.1, which
+speaks **cgroup v1 only**, and Docker Desktop's WSL2 VM is cgroup v2 only. Every
+submission fails with `Failed to create control group`. Four workarounds have
+been tried and all four failed; the details are in `CLAUDE.md`.
+
+You do not need it. **Python runs entirely in the browser** through Pyodide, so
+the Run button works without any sandbox. Only Go and JavaScript go to Judge0,
+and those need a Linux amd64 host with cgroup v1.
+
+---
+
+## Running the checks
+
+CI runs all of these on every pull request, so you are not required to run them
+locally. Running them first is faster than waiting for a red run.
+
+```bash
+cd backend && go test ./...          # the Go suite
+cd web && npx tsc --noEmit           # types
+cd web && npm run lint               # eslint
+```
+
+Two of the checks have traps worth knowing about.
+
+**The store tests skip themselves silently** without a database URL. If you have
+touched anything under `backend/internal/store/`, run them properly:
+
+```bash
+TEST_DATABASE_URL='postgres://syncr:syncrdev@localhost:5433/syncr' \
+  go test ./internal/store/
+```
+
+Without that variable they pass by not running, and it is easy to believe you
+ran the suite when you ran two thirds of it.
+
+**The race detector needs CGO and a gcc**, which Windows does not have by
+default. CI runs `-race` on every pull request on Linux, so you do not strictly
+need it locally. If you have touched `backend/internal/ws/`, run it anyway:
+
+```bash
+GOMAXPROCS=2 go test -race -count=30 ./internal/ws/
+```
+
+The low `GOMAXPROCS` and the repeat count are the point. A race in the hub
+passes happily on an idle developer machine and fails on a loaded CI runner;
+this is the incantation that reproduces those locally.
+
+### The test only a person can run
+
+**Open the room in two browsers.** Half the behaviour in this project only
+exists with two clients connected, and nothing in CI covers it. Sign in as the
+interviewer in one window, open the invite link in a second (a private window
+works), and check that:
+
+- typing in one appears in the other,
+- the cursor of the person *not* typing does not jump,
+- Run output appears on both sides,
+- the candidate path works through the link, not just the interviewer's view.
+
+---
+
+## Pull requests
+
+**One branch per change, branched from `main`.** Branches are deleted
+automatically when the pull request merges, so do not keep a long-lived personal
+branch and reuse it.
+
+```bash
+git switch main && git pull
+git switch -c fix/short-description
+```
+
+**The title must be a conventional commit.** Merges are squashes and the squash
+message is the pull request title, so the title is literally what lands on
+`main`. A workflow checks it:
+
+```
+feat: sync the room language across clients
+fix: stop the caret jumping on a remote edit
+docs: explain the two-browser check
+chore: bump the actions group
+```
+
+Types: `feat`, `fix`, `perf`, `refactor`, `docs`, `test`, `build`, `ci`,
+`chore`, `revert`. The subject must start lowercase — `fix: handle …`, not
+`fix: Handle …`.
+
+**Link the issue.** Put `Closes #123` in the description, not just in a comment.
+Closing keywords only fire at merge time; adding one afterwards does nothing.
+
+**What review expects.** `main` requires a passing CI run (Go with `-race`,
+Next.js, govulncheck, CodeQL) and one approving review from a code owner. Review
+threads must be resolved before merge. Keep pull requests small — a large one is
+not reviewed more thoroughly, it is reviewed less thoroughly.
+
+---
+
+## Conventions
+
+**Go.** Standard layout (`cmd/`, `internal/`). Errors are returned, not
+panicked, for anything expected. `gofmt` is a CI gate.
+
+**The concurrency rule, which is the one that matters.** If you are reaching for
+a `sync.Mutex` to protect room or document state, stop. That state is owned by a
+single goroutine and mutated only through channel messages, and it is why the
+hub is correct without operational transformation. Share memory by
+communicating, not the other way around. A change that introduces a mutex there
+needs an argument in the pull request, not just a passing test.
+
+**If you add shared room state, it has to appear in the snapshot** a late joiner
+receives — otherwise the second person in the room sees a different room from
+the first.
+
+**`internal/ws` must not import `store`.** Authorization arrives as a
+`ws.Authorizer` function so the hub stays a thing that moves text between
+sockets.
+
+**Never execute submitted code in the Go process.** It goes to Judge0 or it runs
+in the candidate's browser. If a change makes shelling out tempting, that is the
+wrong turn.
+
+**Frontend.** TypeScript strict mode, Tailwind for styling, no CSS-in-JS.
+
+---
+
+## Triage
+
+New issues get `needs-triage` automatically, and it clears when a maintainer
+sets a `Priority/` label. Area labels (`backend`, `frontend`, `websocket`, …)
+are applied from the issue form's own dropdown, so filling that in accurately
+saves everyone a step.
+
+`good first issue` marks work that is genuinely self-contained — no cross-stack
+knowledge and no unstated context. If you pick one up, say so in a comment so
+two people do not do it twice.
+
+## Code of conduct
+
+By participating you agree to the [Code of Conduct](CODE_OF_CONDUCT.md).

--- a/README.md
+++ b/README.md
@@ -46,18 +46,23 @@ It is designed for startups, hiring teams, and university placement programmes t
 
 ## Contributing
 
-Contributions, bug reports, and product ideas are welcome.
+Contributions, bug reports, and product ideas are welcome. **[CONTRIBUTING.md](CONTRIBUTING.md)** has the full guide: how to get both halves running locally, the two checks that skip themselves silently, and what review expects.
 
-1. Check existing issues or open one to discuss a substantial change.
-2. Fork the repository and create a focused branch.
-3. Keep each pull request small, clear, and accompanied by relevant tests.
-4. Describe the user-facing impact in the pull request and link the related issue when there is one.
+The short version:
 
-Before opening a pull request, please make sure the relevant frontend or backend checks pass. The automated CI workflow will validate both parts of the project again.
+1. Search the [issues](https://github.com/heshannethmina/SyncR/issues) first. Anything tagged `good first issue` is genuinely self-contained.
+2. Ask in [Discussions](https://github.com/heshannethmina/SyncR/discussions) rather than filing an issue if you are not yet sure it is one. Anything that changes the WebSocket protocol, the schema or the concurrency design should start as a **design proposal** there.
+3. One branch per change, branched from `main`. Branches are deleted on merge, so do not keep one around.
+4. Pull request titles are conventional commits (`fix: stop the caret jumping`) — squash merging makes the title the commit message on `main`, and a workflow checks it.
+5. Link the issue with `Closes #123` in the description. Closing keywords only fire at merge time.
+
+[`CLAUDE.md`](CLAUDE.md) is the design record — why one goroutine owns each document, why tokens are not JWTs, why Python runs in the browser. Read the relevant part before proposing a change to any of it; several of those choices look like accidents and are not.
 
 ## Community
 
-If you would like to help, a great place to start is improving the interface, documentation, accessibility, tests, or interview workflows. Please be kind, specific, and collaborative in issues and pull requests.
+A good place to start is the interface, documentation, accessibility, tests, or the interview workflow itself. Please be kind, specific, and collaborative — see the [Code of Conduct](CODE_OF_CONDUCT.md).
+
+Security problems go to a [private advisory](https://github.com/heshannethmina/SyncR/security/advisories/new), never a public issue. The [security policy](.github/SECURITY.md) explains what is in scope and what is deliberately not.
 
 ---
 


### PR DESCRIPTION
This change adds the repo's public community and security scaffolding: a security policy, contributor guide, code of conduct, and issue/discussion templates. It also adds GitHub triage automation to label new issues by area and to mark unprioritized work, while fixing the root-level SECURITY.MD ignore rule so it no longer hides the published security policy.

## What this changes

<!-- One or two sentences. The title carries the summary; this is for the
     reasoning that will not fit in it. -->

Closes #

## Why

<!-- What was wrong before. If this reverses a decision written down in
     CLAUDE.md, say so explicitly and say why: several of those choices look
     like accidents and are not. -->

## How it was verified

<!-- Delete what does not apply. CI already runs the Go suite with -race, tsc,
     eslint and a Next build on every pull request, so this section is for what
     CI cannot do: what you actually clicked. -->

- [ ] `cd backend && go test ./...`
- [ ] Store tests against a real Postgres (`TEST_DATABASE_URL=...`)
- [ ] `cd web && npx tsc --noEmit && npm run lint`
- [ ] Opened a room in **two browsers** and confirmed live sync still works
- [ ] Checked the candidate path through an invite link, not just the interviewer's

## Notes for the reviewer

<!-- Anything you are unsure about, or deliberately left out. -->

---

<!-- Two things that are easy to trip over here, kept in the template because
     they are cheap to check and expensive to miss:

     * If you touched backend/internal/ws, run the race detector before
       pushing. A race there passes on an idle laptop and fails on a busy CI
       runner: GOMAXPROCS=2 go test -race -count=30 ./internal/ws/

     * If you added shared room state, it has to appear in the snapshot a late
       joiner receives, or the second person in the room sees a different room
       from the first. -->
