### PR TITLE
docs: correct the branch lifecycle after merge

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -142,9 +142,11 @@ works), and check that:
 
 ## Pull requests
 
-**One branch per change, branched from `main`.** Branches are deleted
-automatically when the pull request merges, so do not keep a long-lived personal
-branch and reuse it.
+**One branch per change, branched from `main`.** Merged branches are kept
+rather than deleted, so the history of a change stays reachable after the squash
+commit replaces it — but a branch is still finished once its pull request
+merges. Start a new one for the next piece of work instead of reusing an old
+one: a long-lived branch drifts from `main`, and two people cannot share it.
 
 ```bash
 git switch main && git pull

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ The short version:
 
 1. Search the [issues](https://github.com/heshannethmina/SyncR/issues) first. Anything tagged `good first issue` is genuinely self-contained.
 2. Ask in [Discussions](https://github.com/heshannethmina/SyncR/discussions) rather than filing an issue if you are not yet sure it is one. Anything that changes the WebSocket protocol, the schema or the concurrency design should start as a **design proposal** there.
-3. One branch per change, branched from `main`. Branches are deleted on merge, so do not keep one around.
+3. One branch per change, branched from `main`. Merged branches are kept, but a branch is done once its pull request merges — start a new one rather than reusing it.
 4. Pull request titles are conventional commits (`fix: stop the caret jumping`) — squash merging makes the title the commit message on `main`, and a workflow checks it.
 5. Link the issue with `Closes #123` in the description. Closing keywords only fire at merge time.
 


### PR DESCRIPTION
Update CONTRIBUTING.md and README.md to clarify branch workflow: merged branches are retained rather than automatically deleted, but a branch is finished once its PR is merged. Emphasises creating one branch per change and starting a new branch for subsequent work to avoid drifting and sharing conflicts. Minor wording improvements to the Pull Request guidance in both docs.

## What this changes

<!-- One or two sentences. The title carries the summary; this is for the
     reasoning that will not fit in it. -->

Closes #

## Why

<!-- What was wrong before. If this reverses a decision written down in
     CLAUDE.md, say so explicitly and say why: several of those choices look
     like accidents and are not. -->

## How it was verified

<!-- Delete what does not apply. CI already runs the Go suite with -race, tsc,
     eslint and a Next build on every pull request, so this section is for what
     CI cannot do: what you actually clicked. -->

- [ ] `cd backend && go test ./...`
- [ ] Store tests against a real Postgres (`TEST_DATABASE_URL=...`)
- [ ] `cd web && npx tsc --noEmit && npm run lint`
- [ ] Opened a room in **two browsers** and confirmed live sync still works
- [ ] Checked the candidate path through an invite link, not just the interviewer's

## Notes for the reviewer

<!-- Anything you are unsure about, or deliberately left out. -->

---

<!-- Two things that are easy to trip over here, kept in the template because
     they are cheap to check and expensive to miss:

     * If you touched backend/internal/ws, run the race detector before
       pushing. A race there passes on an idle laptop and fails on a busy CI
       runner: GOMAXPROCS=2 go test -race -count=30 ./internal/ws/

     * If you added shared room state, it has to appear in the snapshot a late
       joiner receives, or the second person in the room sees a different room
       from the first. -->
